### PR TITLE
Update flake inputs: 3 packages updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760662441,
-        "narHash": "sha256-mlDqR1Ntgs9uYYEAUR1IhamKBO0lxoNS4zGLzEZaY0A=",
+        "lastModified": 1760887455,
+        "narHash": "sha256-/xU8iYZjolWbMUNBQF6af5zgGs73Qw21WMgz1tLs3Yw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "722792af097dff5790f1a66d271a47759f477755",
+        "rev": "aeabc1ac63e6ebb8ba4714c4abdfe0556f2de765",
         "type": "github"
       },
       "original": {
@@ -559,11 +559,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1760769015,
-        "narHash": "sha256-iuaC+TN2axPs6d8PhVeGPffs6DrMmlj3wp7ArODvlvM=",
+        "lastModified": 1760926463,
+        "narHash": "sha256-TtoK4U4nonlRjOVYxT9vFu3KFAJ++f9QHJ7+dkLz7Q8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1a8abfdf07ab13a66d5d0dadfe267b72d7826df4",
+        "rev": "e996452203349694b96e4b30f25f13dbb37c13f0",
         "type": "github"
       },
       "original": {
@@ -769,11 +769,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760768820,
-        "narHash": "sha256-rg4fJ8ocx3rCz//eajnxBmKZV4qulLtEPtBc+mtgrt4=",
+        "lastModified": 1760898315,
+        "narHash": "sha256-d2qbZpREjUQm65lzS70b2TVgTfOpAjQUZa+FS58+WnA=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "fd874a0b5f281bc4e173d81b03726d7fc7983cfd",
+        "rev": "5e52b6a9ec07d22c9555891005b1b39f1bbd83ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This PR updates flake inputs to their latest versions.

**Updated inputs:**
- [home-manager](https://github.com/nix-community/home-manager/commit/aeabc1ac63e6ebb8ba4714c4abdfe0556f2de765)
```diff
-722792a
+aeabc1a
```
- [nixpkgs](https://github.com/nixos/nixpkgs/commit/e996452203349694b96e4b30f25f13dbb37c13f0)
```diff
-1a8abfd
+e996452
```
- [zen-browser](https://github.com/0xc000022070/zen-browser-flake/commit/5e52b6a9ec07d22c9555891005b1b39f1bbd83ed)
```diff
-fd874a0
+5e52b6a
```


**Summary:**
- Updated 3 packages: home-manager,nixpkgs,zen-browser
- Updated flake.lock with latest input versions