### PR TITLE
Update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
     "dotfiles": {
       "flake": false,
       "locked": {
-        "lastModified": 1761145416,
-        "narHash": "sha256-aickOoyEqUlcG+7HC4SOf3csAKz37aUBb2wXlcpvoWY=",
+        "lastModified": 1761518051,
+        "narHash": "sha256-y2GeJlRxO6XohuFvR9/f4lU0lzV6aQnOd0bkp+SVewo=",
         "owner": "fbosch",
         "repo": "dotfiles",
-        "rev": "ebde6485fc051d2afa588e2cf86e2a221bb137fe",
+        "rev": "1f10497687b597541dfefc61544fdad40330fea1",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1761081701,
-        "narHash": "sha256-IwpfaKg5c/WWQiy8b5QGaVPMvoEQ2J6kpwRFdpVpBNQ=",
+        "lastModified": 1761530345,
+        "narHash": "sha256-+9+YCK9Lh6GThkXu/8JTxMFUnImIdZpb8ElUh6/F5Y8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9b4a2a7c4fbd75b422f00794af02d6edb4d9d315",
+        "rev": "bbaeb9f1c29e79bb1653b32c3d73244cdf4bd888",
         "type": "github"
       },
       "original": {
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760659005,
-        "narHash": "sha256-wyS6tXYJuzbwckOeaCoRtT4qIG2UZ0YvSZx7EBNjTV0=",
+        "lastModified": 1761249285,
+        "narHash": "sha256-70dEwL5p3CB/00ODs2RHWUKTyafB+PF4Ld7IEMuO+no=",
         "owner": "hyprwm",
         "repo": "hyprland-plugins",
-        "rev": "a5a6f93d72d5fb37e78b98c756cfd8b340e71a19",
+        "rev": "81f6d1426537981fcbb921f8b5e470b1280ef8f3",
         "type": "github"
       },
       "original": {
@@ -571,11 +571,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1760878510,
-        "narHash": "sha256-K5Osef2qexezUfs0alLvZ7nQFTGS9DL2oTVsIXsqLgs=",
+        "lastModified": 1761373498,
+        "narHash": "sha256-Q/uhWNvd7V7k1H1ZPMy/vkx3F8C13ZcdrKjO7Jv7v0c=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5e2a59a5b1a82f89f2c7e598302a9cacebb72a67",
+        "rev": "6a08e6bb4e46ff7fcbb53d409b253f6bad8a28ce",
         "type": "github"
       },
       "original": {
@@ -722,11 +722,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1761095432,
-        "narHash": "sha256-kQ5Q7zj6hsTiQBLEeNsWV6L11F8EJdrVJO99pdRK0cE=",
+        "lastModified": 1761519336,
+        "narHash": "sha256-v1VKJEUre771zhAzZIXq7eC94XjloO4V1JKiBft1ekE=",
         "owner": "vicinaehq",
         "repo": "vicinae",
-        "rev": "17576c8a741ebe80d17360acce0ed9c31bec146e",
+        "rev": "294db4f06e26c0088cec52dd8cace359c70fcd02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Inputs updated: dotfiles home-manager hyprland-plugins nixpkgs vicinae

- [dotfiles](https://github.com/fbosch/dotfiles/commit/f4lU0lzV6aQnOd0bkp%2BSVewo%3D)
```diff
-ebde648
+f4lU0lz
```
- [home-manager](https://github.com/nix-community/home-manager/commit/F5Y8%3D)
```diff
-WWQiy8b
+F5Y8%3D
```
- [hyprland-plugins](https://github.com/hyprwm/hyprland-plugins/commit/00ODs2RHWUKTyafB%2BPF4Ld7IEMuO%2Bno%3D)
```diff
-a5a6f93
+00ODs2R
```
- [nixpkgs](https://github.com/nixos/nixpkgs/commit/vkx3F8C13ZcdrKjO7Jv7v0c%3D)
```diff
-5e2a59a
+vkx3F8C
```
- [vicinae](https://github.com/vicinaehq/vicinae/commit/294db4f06e26c0088cec52dd8cace359c70fcd02?narHash=sha256-v1VKJEUre771zhAzZIXq7eC94XjloO4V1JKiBft1ekE%3D)
```diff
-17576c8
+294db4f
```