### PR TITLE
Fix bootstrap system detection without nix-command

### DIFF
--- a/scripts/bootstrap-machine.sh
+++ b/scripts/bootstrap-machine.sh
@@ -223,7 +223,7 @@ else
   machine_name="$(gum input --prompt "Machine name: " --value "$default_host_name" --placeholder "directory under machines/")"
   preset="$(gum choose --header "Select host preset" "minimal" "desktop" "server")"
   role="$(gum choose --header "Select host role" "server" "desktop" "laptop" "vm")"
-  system="$(nix eval --impure --raw --expr builtins.currentSystem)"
+  system="$(nix-instantiate --eval --expr builtins.currentSystem | tr -d '"')"
 
   validate_name "$machine_name" "Machine name"
 


### PR DESCRIPTION
## Summary

Replace `nix eval --impure --raw --expr builtins.currentSystem` with `nix-instantiate --eval --expr builtins.currentSystem | tr -d '"'` in `scripts/bootstrap-machine.sh`.

This keeps the fresh-NixOS bootstrap path independent of the experimental `nix-command` feature.

## Verification

- Diff is limited to one line in `scripts/bootstrap-machine.sh`.
- Branch is 1 commit ahead of `master` with no other changes.