### PR TITLE
Fix AGS Home Manager package ownership inventory

### DIFF
--- a/tests/nix-unit/ownership-boundaries.nix
+++ b/tests/nix-unit/ownership-boundaries.nix
@@ -86,6 +86,7 @@ in
       "applications/gaming/steam/theme.nix"
       "applications/windows.nix"
       "desktop/update-checker.nix"
+      "desktop/wayland/ags.nix"
       "dotfiles.nix"
     ];
   };


### PR DESCRIPTION
## Summary

Update the Home Manager package-ownership invariant to include `modules/desktop/wayland/ags.nix`.

`ags.nix` intentionally owns `agsBundleRuntime`: it is a user-scoped runtime helper coupled directly to the AGS Home Manager module. The ownership test is an explicit inventory of approved `home.packages` declarations, so the stale inventory should be updated rather than moving this package into an unrelated layer.

## Verification

- Diff is limited to the ownership-boundary test.
- Adds the missing AGS owner in sorted order.
- Intended to restore the currently failing `ownershipBoundaries.packageOwnership.testOnlyApprovedLiteralHomePackageOwnersRemain` check on `master`.