### PR TITLE
feat(applications): configure Mission Center monitoring

### DIFF
--- a/modules/applications/system/default.nix
+++ b/modules/applications/system/default.nix
@@ -3,8 +3,21 @@
     nixos.applications = { pkgs, ... }: {
       environment.systemPackages = with pkgs; [
         hardinfo2
-        resources
+        mission-center
       ];
+
+      # Mission Center uses nethogs for per-process network monitoring.
+      security.wrappers.nethogs = {
+        source = "${pkgs.nethogs}/bin/nethogs";
+        owner = "root";
+        group = "root";
+        capabilities = "cap_net_admin,cap_net_raw,cap_dac_read_search,cap_sys_ptrace+pe";
+      };
+
+      # Allow Mission Center to read Intel RAPL energy counters for CPU power usage.
+      services.udev.extraRules = ''
+        SUBSYSTEM=="powercap", KERNEL=="intel-rapl*", RUN+="${pkgs.coreutils}/bin/chmod a+r /sys/%p/energy_uj"
+      '';
     };
   };
 }


### PR DESCRIPTION
## Summary

- replace GNOME Resources with Mission Center in the system applications module
- add a NixOS security wrapper for `nethogs` with the capabilities Mission Center requires for per-process network monitoring
- add a declarative udev rule granting read access to Intel RAPL energy counters for CPU power monitoring

This expresses Mission Center's Linux setup declaratively instead of relying on its privileged setup script, which cannot mutate Nix store binaries.

## Validation

- verified the resulting branch contains only the intended `modules/applications/system/default.nix` change
- CI should run the repository's normal flake checks