### PR TITLE
Use Vision cursor theme

### DIFF
--- a/modules/desktop/display-manager/default.nix
+++ b/modules/desktop/display-manager/default.nix
@@ -139,7 +139,7 @@ in
       };
 
       systemd.services.display-manager.environment = {
-        XCURSOR_THEME = "Simp1e";
+        XCURSOR_THEME = "Vision-White";
         XCURSOR_SIZE = "24";
         XCURSOR_PATH = "/run/current-system/sw/share/icons";
       };

--- a/modules/desktop/gnome/config/gtk-3-settings.ini
+++ b/modules/desktop/gnome/config/gtk-3-settings.ini
@@ -2,7 +2,7 @@
 gtk-theme-name=MonoThemeDark
 gtk-icon-theme-name=Win11
 gtk-font-name=SF Pro Display 11
-gtk-cursor-theme-name=Simp1e
+gtk-cursor-theme-name=Vision-White
 gtk-cursor-theme-size=24
 gtk-toolbar-style=GTK_TOOLBAR_ICONS
 gtk-toolbar-icon-size=GTK_ICON_SIZE_LARGE_TOOLBAR

--- a/modules/desktop/gnome/config/gtk-4-settings.ini
+++ b/modules/desktop/gnome/config/gtk-4-settings.ini
@@ -2,6 +2,6 @@
 gtk-theme-name=MonoThemeDark
 gtk-icon-theme-name=Win11
 gtk-font-name=SF Pro Display 11
-gtk-cursor-theme-name=Simp1e
+gtk-cursor-theme-name=Vision-White
 gtk-cursor-theme-size=24
 gtk-application-prefer-dark-theme=1

--- a/modules/desktop/gnome/cursors/default.nix
+++ b/modules/desktop/gnome/cursors/default.nix
@@ -1,0 +1,42 @@
+{
+  flake.modules.nixos.desktop =
+    { lib, pkgs, ... }:
+    let
+      visionCursor = pkgs.stdenvNoCC.mkDerivation (finalAttrs: {
+        pname = "vision-cursor";
+        version = "1.0";
+
+        srcs = [
+          (pkgs.fetchurl {
+            url = "https://github.com/zDyant/Vision-Cursor/releases/download/v${finalAttrs.version}/Vision-Black-Linux.tar.gz";
+            hash = "sha256-Mgz00DxJ4g6JCu5D1V/O507pJN9iEGw37SzFHAc9tVY=";
+          })
+          (pkgs.fetchurl {
+            url = "https://github.com/zDyant/Vision-Cursor/releases/download/v${finalAttrs.version}/Vision-White-Linux.tar.gz";
+            hash = "sha256-IYwWAyiNjosGxC5vddvnfGwtVghWOoCl0hXqxVsKDh4=";
+          })
+        ];
+
+        sourceRoot = ".";
+        dontBuild = true;
+
+        installPhase = ''
+          runHook preInstall
+
+          mkdir -p $out/share/icons
+          cp -R Vision-Black Vision-White $out/share/icons/
+
+          runHook postInstall
+        '';
+
+        meta = {
+          description = "Clean cursor inspired by Windows 11 style";
+          homepage = "https://github.com/zDyant/Vision-Cursor";
+          license = lib.licenses.cc-by-nc-nd-40;
+        };
+      });
+    in
+    {
+      environment.systemPackages = [ visionCursor ];
+    };
+}

--- a/modules/desktop/gnome/default.nix
+++ b/modules/desktop/gnome/default.nix
@@ -11,7 +11,7 @@ in
         monospace-font-name = "SF Mono 11";
         gtk-theme = "MonoThemeDark";
         icon-theme = "Win11-dark";
-        cursor-theme = "Simp1e";
+        cursor-theme = "Vision-White";
         cursor-size = 24;
         font-name = "SF Pro Display 11";
         text-scaling-factor = 1.0;

--- a/modules/desktop/hyprland.nix
+++ b/modules/desktop/hyprland.nix
@@ -67,7 +67,7 @@
           environment = {
             sessionVariables = {
               EMOJI_FONT = "Apple Color Emoji";
-              XCURSOR_THEME = "Simp1e";
+              XCURSOR_THEME = "Vision-White";
               XCURSOR_SIZE = "24";
               NIXOS_OZONE_WL = "1";
               GDK_BACKEND = "wayland,x11";

--- a/modules/hosts/rvn-pc/platform/system/default.nix
+++ b/modules/hosts/rvn-pc/platform/system/default.nix
@@ -5,7 +5,7 @@
       environment.etc."xdg/weston/weston.ini".text = ''
         [core]
         shell=kiosk
-        cursor-theme=Simp1e
+        cursor-theme=Vision-White
         cursor-size=24
 
         [output]
@@ -19,7 +19,7 @@
 
       services.displayManager.sddm.settings = {
         Theme = {
-          CursorTheme = "Simp1e";
+          CursorTheme = "Vision-White";
           CursorSize = 24;
         };
         Wayland.CompositorCommand = "${pkgs.weston}/bin/weston --shell=kiosk -c /etc/xdg/weston/weston.ini";


### PR DESCRIPTION
## What changed

- add a Nix package for Vision Cursor v1.0 using the upstream Linux release archives and fixed hashes
- switch GNOME, GTK 3/4, Hyprland, SDDM, and Weston from `Simp1e` to `Vision-White`
- keep the existing 24 px cursor size

## Why

Vision Cursor follows the Windows 11 pointer style more closely and fits the existing Win11/Fluent-oriented desktop iconography better than Simp1e.

## Validation

- compared `agent/use-vision-cursor` against `master`; the branch only changes cursor configuration and adds the cursor package module
- package source URLs and hashes match the upstream author's published Nix package definition
- local Nix evaluation was not run from this chat environment; CI should provide the repository-level evaluation/check coverage

## Note

The existing `pkgs.simp1e-cursors` package entry in the icon package module remains installed but is no longer selected anywhere. It can be removed separately if desired; this PR keeps the behavioral change isolated from the large icon-theme module.