### PR TITLE
fix(ci): skip Trivy for unavailable container images

### DIFF
--- a/.github/workflows/container-security-scan.yml
+++ b/.github/workflows/container-security-scan.yml
@@ -76,14 +76,20 @@ jobs:
           echo "safe-name=$SAFE_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Pull container image
+        id: pull
         run: |
+          set -euo pipefail
+
           echo "Pulling ${{ matrix.image }}"
-          docker pull "${{ matrix.image }}" || {
+          if docker pull "${{ matrix.image }}"; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
             echo "::warning::Failed to pull ${{ matrix.image }} - may be a local image or invalid reference"
-            exit 0
-          }
+          fi
 
       - name: Scan image with Trivy
+        if: steps.pull.outputs.available == 'true'
         uses: ./.github/actions/trivy-scan
         with:
           image-ref: ${{ matrix.image }}

--- a/.github/workflows/container-security-scan.yml
+++ b/.github/workflows/container-security-scan.yml
@@ -3,6 +3,8 @@ name: Container Security Scan
 on:
   pull_request:
     paths:
+      - ".github/actions/trivy-scan/**"
+      - ".github/workflows/container-security-scan.yml"
       - "modules/services/containers/**/*.nix"
       - "modules/hosts/**/*.nix"
   workflow_dispatch:
@@ -108,9 +110,10 @@ jobs:
           if [ "${{ needs.extract-images.outputs.has-images }}" == "true" ]; then
             echo "✅ Container security scan completed"
             echo ""
-            echo "Scanned images:"
+            echo "Discovered images:"
             echo "${{ needs.extract-images.outputs.images }}" | jq -r '.[]' | sed 's/^/  - /'
             echo ""
+            echo "Pullable images were scanned; unavailable references were skipped with warnings."
             echo "Check the Security tab for detailed vulnerability reports."
           else
             echo "ℹ️ No container images to scan in this PR"


### PR DESCRIPTION
## Summary

- record whether each discovered container image can be pulled
- run Trivy only when the pull succeeds
- preserve the existing warning-and-skip behavior for locally built or otherwise unavailable image references
- run the container scan when its workflow or shared Trivy action changes
- report matrix entries as discovered images rather than claiming skipped references were scanned

## Root cause

The pull step handled `docker pull` failures successfully, so the workflow continued into the unconditional Trivy step. Trivy then attempted to pull the same unavailable images and failed the matrix jobs. This affected locally built images such as the Helium and Priceghost images; it was not a reported vulnerability finding.

The workflow path filter also excluded the scanner workflow and composite action, preventing scanner-only PRs from exercising the affected workflow.

## Validation

- `Container Security Scan` passes on this PR
- local-only Helium and Priceghost matrix jobs succeed with Trivy explicitly skipped
- pullable registry images continue through Trivy and SARIF upload successfully
- `Secret Scan` passes
- workflow YAML parses successfully
- pull-step shell syntax is valid
- the branch changes only `.github/workflows/container-security-scan.yml`
