### PR TITLE
vision-cursor: fix Linux pointer alias packaging

### DIFF
--- a/pkgs/by-name/vision-cursor/package.nix
+++ b/pkgs/by-name/vision-cursor/package.nix
@@ -31,39 +31,23 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         exit 1
       fi
 
-      for requiredCursor in pointer link; do
-        if [ ! -e "$cursors/$requiredCursor" ]; then
-          echo "Vision cursor theme is missing $cursors/$requiredCursor" >&2
-          exit 1
+      pointerTarget=""
+      for candidate in hand2 pointing_hand hand1 hand link; do
+        if [ -e "$cursors/$candidate" ]; then
+          pointerTarget="$(readlink -f "$cursors/$candidate")"
+          break
         fi
       done
 
-      defaultTarget="$(readlink -f "$cursors/pointer")"
-      linkTarget="$(readlink -f "$cursors/link")"
-
-      if cmp -s "$defaultTarget" "$linkTarget"; then
-        echo "Vision cursor pointer and link assets unexpectedly resolve to the same cursor" >&2
+      if [ -z "$pointerTarget" ]; then
+        echo "Vision cursor theme has no known clickable-pointer cursor" >&2
         exit 1
       fi
 
-      # Upstream follows Windows naming: pointer is the default arrow and link
-      # is the hand. Preserve the arrow before normalizing XCursor aliases.
-      cp --dereference "$defaultTarget" "$cursors/.vision-default"
-      cp --dereference "$linkTarget" "$cursors/.vision-pointer"
-
-      # Keep aliases that previously resolved to the Windows-named pointer on
-      # the default arrow after `pointer` gains Linux hand semantics.
-      for cursor in "$cursors"/*; do
-        if [ -L "$cursor" ] && [ "$(readlink -f "$cursor")" = "$defaultTarget" ]; then
-          ln -sfn .vision-default "$cursor"
-        fi
-      done
-
-      for cursorName in default arrow left_ptr; do
-        if [ ! -e "$cursors/$cursorName" ]; then
-          ln -s .vision-default "$cursors/$cursorName"
-        fi
-      done
+      # The Linux release already contains an XCursor theme, but not every
+      # compatibility alias used by GTK/X11 applications. Preserve all
+      # existing names and add only missing aliases to the existing hand.
+      cp --dereference "$pointerTarget" "$cursors/.vision-pointer"
 
       for cursorName in \
         pointer \
@@ -74,12 +58,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         9d800788f1b08800ae810202380a0822 \
         e29285e634086352946a0e7090d73106
       do
-        rm -f "$cursors/$cursorName"
-        ln -s .vision-pointer "$cursors/$cursorName"
+        if [ ! -e "$cursors/$cursorName" ]; then
+          ln -s .vision-pointer "$cursors/$cursorName"
+        fi
       done
-
-      rm -f "$cursors/link"
-      ln -s .vision-pointer "$cursors/link"
     done
   '';
 


### PR DESCRIPTION
## What changed

- fix the Vision Cursor compatibility patch to match the actual Linux release layout
- stop requiring `cursors/pointer`, which is absent from the upstream Linux archive
- detect the existing clickable hand cursor from standard candidates (`hand2`, `pointing_hand`, `hand1`, `hand`, then `link`)
- preserve every existing cursor name and add only missing compatibility aliases for `pointer`, hand aliases, and the standard XCursor pointer hashes

## Root cause

PR #199 inferred the Linux cursor layout from the upstream Windows source, where `pointer.cur` is the arrow and `link.cur` is the hand. The packaged Linux release is already an XCursor theme and does not expose `Vision-*/cursors/pointer`, so the package failed during `patchPhase` before it could install.

The compatibility fix does not need to reinterpret or replace existing cursor names. It only needs to supply aliases that applications may request but the theme does not provide.

## Validation

- reproduced the reported failure condition conceptually: `pointer` is absent before alias normalization
- exercised the new alias logic against a mock XCursor theme with no `pointer` entry and an existing `hand2` cursor; `pointer`, `hand1`, `pointing_hand`, and both standard pointer hashes resolve to the hand while the existing default arrow remains unchanged
- branch is one commit ahead of `master` and changes only `pkgs/by-name/vision-cursor/package.nix`
- full Nix build is not available in this execution environment; the reported `nixos-rebuild` failure is the regression this PR addresses
