### PR TITLE
refactor: remove duplicate Hyprland plugin build path

### DIFF
--- a/justfile
+++ b/justfile
@@ -14,10 +14,6 @@ build-pc:
 build-srv:
     nh os build .#rvn-srv
 
-# Build a local Hyprland plugin against the pinned compositor toolchain
-build-hyprland-plugin plugin:
-    HYPRLAND_PLUGIN="{{plugin}}" nix build --impure --expr 'let root = ./.; flake = builtins.getFlake ("git+file://" + toString root); pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; }; package = root + "/pkgs/by-name/${builtins.getEnv "HYPRLAND_PLUGIN"}/package.nix"; in pkgs.callPackage package { inputs = flake.inputs; }' --no-link --print-out-paths
-
 # Build custom container images for helium
 build-helium:
     sudo build-helium-images


### PR DESCRIPTION
## Summary

- remove the generic `build-hyprland-plugin` recipe from `justfile`
- keep `.#cursor-outline` as the single package evaluation path
- avoid the separate impure `builtins.getFlake` / direct `callPackage` workflow

## Rationale

`cursor-outline` is already exported through the repository's `pkgs/by-name` package machinery and consumed as `pkgs.local.cursor-outline`. The removed recipe independently reconstructed the package evaluation with a different package scope and generalized that path despite having only one current local Hyprland plugin.

The canonical development command remains:

```sh
nix build .#cursor-outline
```

## Validation

- verified the branch changes only `justfile` with four deletions
- local Nix validation was not available in the execution environment; repository CI should exercise the flake/package evaluation
