### PR TITLE
chore(renovate): rebase stale dependency branches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,7 @@
   ],
   "automerge": false,
   "platformAutomerge": false,
+  "rebaseWhen": "behind-base-branch",
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,
   "osvVulnerabilityAlerts": true,


### PR DESCRIPTION
## Summary

- configure Renovate with `rebaseWhen: "behind-base-branch"`
- keep automated dependency PRs based on the latest `master`

## Rationale

The current Renovate PRs can remain on an older base revision until they conflict or are manually retried. This caused dependency PRs to keep running CI without a repository-level nix-unit fix that had already landed on `master`.

Using `behind-base-branch` makes Renovate regenerate stale branches whenever the base branch advances, so repository fixes are incorporated before CI is evaluated again.

## Validation

- branch is one commit ahead of `master`
- diff changes only `.github/renovate.json`
- one-line configuration change